### PR TITLE
Fixed hook name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   loadPlugin: function () {
     module.exports = Object.assign(module.exports, {
-      'file:hook:require': function () {
+      'migrator:migration:hook:require': function () {
         // We use ts-node because the official TypeScript module does not implement the register() method
         require('ts-node/register');
 
@@ -17,5 +17,5 @@ module.exports = {
     delete module.exports.loadPlugin;
   },
   name: 'ts',
-  hooks: ['file:hook:require'],
+  hooks: ['migrator:migration:hook:require'],
 };


### PR DESCRIPTION
For version 0.11.6 (and some before) db-migrate changed the plugin name from "file:hook:require" to "migrator:migration:hook:require"